### PR TITLE
Bugfix: using non-existing id with relation model API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,29 @@
+2018-08-21, Version 3.0.0
+=========================
+
+ * upgrade dependencies (Raymond Feng)
+
+ * Settings bug fix when passing an host without a port (Antonio Trapani)
+
+ * Fix for error-logging if error is not a string (makowski)
+
+ * Fix for destroyAll (GARETH CLYNE)
+
+ * Update paid support URL (Siddhi Pai)
+
+ * Start 3.x + drop support for Node v0.10/v0.12 (siddhipai)
+
+ * Drop support for Node v0.10 and v0.12 (Siddhi Pai)
+
+ * Start the development of the next major version (Siddhi Pai)
+
+ * fixes #44: stop destroyAll returning errors (Robert McLeod)
+
+ * refs #41: stop upsert existing model returns string on non-string fields (Robert McLeod)
+
+ * Update README.md (Rand McKinney)
+
+
 2016-10-17, Version 0.1.0
 =========================
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -382,6 +382,9 @@ BridgeToRedis.prototype.updateOrCreate = function(model, data, callback) {
   if (!data.id) {
     return this.create(model, data, callback);
   }
+
+  var self = this;
+
   var client = this.client;
   this.save(model, data, function(error, obj) {
     var key = 'id:' + model;
@@ -393,7 +396,7 @@ BridgeToRedis.prototype.updateOrCreate = function(model, data, callback) {
       }
     });
     function ok() {
-      callback(error, obj);
+      callback(error, self.fromDb(model, obj));
     }
   });
 };
@@ -673,4 +676,3 @@ BridgeToRedis.prototype.disconnect = function disconnect(cb) {
 BridgeToRedis.prototype.transaction = function() {
   throw new Error(g.f('not implemented'));
 };
-

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -485,6 +485,12 @@ BridgeToRedis.prototype.all = function all(model, filter, callback) {
   var innerSetUsed = false;
   var trans = this.client.transaction();
 
+  // fixes issue #44 where destroy all returns an error due to trying to execute
+  // an empty where filter
+  if (filter.where && Object.keys(filter.where).length === 0) {
+    delete filter.where;
+  }
+
   if (!filter) {
     filter = {order: 'id'};
   }
@@ -506,7 +512,7 @@ BridgeToRedis.prototype.all = function all(model, filter, callback) {
     var indexes = pi[0];
     var noIndexes = pi[1];
 
-    if (noIndexes.length) {
+    if (noIndexes && noIndexes.length) {
       throw new Error(g.f('%s: no indexes found for %s ' +
             'impossible to sort and filter using {{redis}} connector',
             model, noIndexes.join(', ')));
@@ -673,4 +679,3 @@ BridgeToRedis.prototype.disconnect = function disconnect(cb) {
 BridgeToRedis.prototype.transaction = function() {
   throw new Error(g.f('not implemented'));
 };
-

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -23,18 +23,17 @@ exports.initialize = function initializeSchema(dataSource, callback) {
     }
   }
 
-  var params = [];
+  if (!dataSource.settings.options) {
+    dataSource.settings.options = {};
+  }
   if (dataSource.settings.port) {
-    params.push(dataSource.settings.port);
+    dataSource.settings.options.port = dataSource.settings.port;
   }
   if (dataSource.settings.host) {
-    params.push(dataSource.settings.host);
-  }
-  if (dataSource.settings.options) {
-    params.push(dataSource.settings.options);
+    dataSource.settings.options.host = dataSource.settings.host;
   }
 
-  dataSource.client = redis.createClient.apply(redis.createClient, params);
+  dataSource.client = redis.createClient(dataSource.settings.options);
   dataSource.client.auth(dataSource.settings.password);
   var callbackCalled = false;
   var database = dataSource.settings.hasOwnProperty('database') &&

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -34,7 +34,9 @@ exports.initialize = function initializeSchema(dataSource, callback) {
   }
 
   dataSource.client = redis.createClient(dataSource.settings.options);
-  dataSource.client.auth(dataSource.settings.password);
+  if (dataSource.settings.password) {
+    dataSource.client.auth(dataSource.settings.password);
+  }
   var callbackCalled = false;
   var database = dataSource.settings.hasOwnProperty('database') &&
     dataSource.settings.database;

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -613,6 +613,17 @@ BridgeToRedis.prototype.all = function all(model, filter, callback) {
         return callback(err);
       }
 
+      // Detect "not found" use case from redis, i.e. replies = [ null ]
+      // This is especially important when querying with relation model,
+      // e.g. GET /modelA/<id>/modelB or DELETE /modelA/<id>/modelB but
+      // when modelA with <id> does not exist. Without this fix, code would
+      // get/delete *ALL* instances of modelB, regardless to which modelA
+      // it belongs to.
+      if (replies && Array.isArray(replies) && replies.length === 1 &&
+        replies[0] === null) {
+        return callback(null, []);
+      }
+
       var objs = (replies || []).map(function(r) {
         return redis.fromDb(model, r, filter.fields);
       });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha",
+    "test": "mocha --exit",
     "posttest": "npm run lint"
   },
   "repository": {
@@ -31,16 +31,16 @@
   },
   "homepage": "https://github.com/strongloop/loopback-connector-redis#readme",
   "devDependencies": {
-    "bluebird": "^2.9.0",
+    "bluebird": "^3.5.1",
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
     "loopback-datasource-juggler": "^3.0.0",
-    "mocha": "^2.3.4",
+    "mocha": "^5.2.0",
     "should": "~8.0.2"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "redis": "^0.12.1",
-    "strong-globalize": "^2.6.2"
+    "async": "^2.6.1",
+    "redis": "^2.8.0",
+    "strong-globalize": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-redis",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0",
   "description": "The official Redis connector for the LoopBack Framework.",
   "engines": {
     "node": ">=4"

--- a/test/destroy-all-models.js
+++ b/test/destroy-all-models.js
@@ -1,0 +1,37 @@
+'use strict';
+
+describe('when a model does exist', function() {
+  var should = require('./init.js');
+  var db, Model;
+  var id = 0;
+
+  before(defineModel);
+  beforeEach(createNewModel);
+
+  describe('destroyAll', function() {
+    it('should destroy all models', function(done) {
+      Model.destroyAll(function(err) {
+        if (err) return done(err);
+
+        Model.find(function(err, instances) {
+          if (err) return done(err);
+          instances.should.have.lengthOf(0);
+          done();
+        });
+      });
+    });
+  });
+
+  function defineModel() {
+    db = getSchema();
+    Model = db.define('Model', {name: String});
+  }
+
+  function createNewModel(done) {
+    Model.create({name: 'horse'}, function(err, m) {
+      if (err) return done(err);
+      id = m.id;
+      done();
+    });
+  }
+});

--- a/test/upsert-no-strings.js
+++ b/test/upsert-no-strings.js
@@ -1,0 +1,42 @@
+'use strict';
+
+describe('when a model does exist', function() {
+  var should = require('./init.js');
+  var db, Model;
+  var id = 0;
+
+  before(createNewModel);
+
+  describe('updateOrCreate', function() {
+    it('should not return boolean field as string', function(done) {
+      var data = {id: id, enabled: true};
+      Model.updateOrCreate(data, function(err, instance) {
+        if (err) return done(err);
+        instance.should.have.property('enabled');
+        instance.enabled.should.equal(true);
+        done();
+      });
+    });
+
+    it('should not return number field as string', function(done) {
+      var data = {id: id, enabled: true};
+      Model.updateOrCreate(data, function(err, instance) {
+        if (err) return done(err);
+        instance.should.have.property('count');
+        instance.count.should.equal(4);
+        done();
+      });
+    });
+  });
+
+  function createNewModel(done) {
+    db = getSchema();
+    Model = db.define('Model', {name: String, enabled: Boolean, count: Number});
+
+    Model.create({name: 'horse', enabled: false, count: 4}, function(err, m) {
+      if (err) return done(err);
+      id = m.id;
+      done();
+    });
+  }
+});


### PR DESCRIPTION
- When using relation model REST API, e.g. GET/DELETE /modelA/<id>/modelB and when using non-existing modelA <id>, the connection bug retrieved/deleted ALL modelB instances.
- Also fixes a use case where GET /modelA/<id> with non-existing <id> responds now HTTP 404 instead of 200